### PR TITLE
Added metadata index page for datalight.

### DIFF
--- a/datalight_index.md
+++ b/datalight_index.md
@@ -1,12 +1,14 @@
 ---
+---
+
 {% comment %} 
   # This page provides links to the experiment metadata files in the "/_includes/checklists" folder so DataLight can read them.
 {% endcomment %} 
 
-{% for exp in site.experiments -%}
-  {% assign exp_title = exp.title | replace: " ", "-" | downcase | replace: "(", "_" | replace: ")", "_" -%}
-  {% assign filename = exp.url | split: "/" -%}
-  {% if filename[-1] != "index" -%}
-    <pre>https://raw.githubusercontent.com/LightForm-group/wiki/master/_includes/checklists/{{ exp_title -}}.yml</pre>
-  {% endif %}
-{% endfor %}
+{%- for exp in site.experiments -%}
+  {%- assign exp_title = exp.title | replace: " ", "-" | downcase | replace: "(", "_" | replace: ")", "_" -%}
+  {%- assign filename = exp.url | split: "/" -%}
+  {%- if filename[-1] != "index" -%}
+    <pre>https://raw.githubusercontent.com/LightForm-group/wiki/master/_includes/checklists/{{- exp_title -}}.yml</pre>
+  {%- endif -%}
+{%- endfor -%}

--- a/datalight_index.md
+++ b/datalight_index.md
@@ -1,0 +1,14 @@
+---
+layout: default
+title: Datalight index
+page_width: wide
+show_breadcrumbs: false
+show_meta: false
+---
+
+{% for exp in site.experiments -%}
+  {% assign exp_title = exp.title | replace: " ", "-" | downcase | replace: "(", "_" | replace: ")", "_" -%}
+  {% if exp_title != "experiments" -%}
+    <pre>https://raw.githubusercontent.com/LightForm-group/wiki/master/_includes/checklists/{{ exp_title -}}.yml</pre>
+  {% endif %}
+{% endfor %}

--- a/datalight_index.md
+++ b/datalight_index.md
@@ -1,14 +1,12 @@
 ---
-layout: default
-title: Datalight index
-page_width: wide
-show_breadcrumbs: false
-show_meta: false
----
+{% comment %} 
+  # This page provides links to the experiment metadata files in the "/_includes/checklists" folder so DataLight can read them.
+{% endcomment %} 
 
 {% for exp in site.experiments -%}
   {% assign exp_title = exp.title | replace: " ", "-" | downcase | replace: "(", "_" | replace: ")", "_" -%}
-  {% if exp_title != "experiments" -%}
+  {% assign filename = exp.url | split: "/" -%}
+  {% if filename[-1] != "index" -%}
     <pre>https://raw.githubusercontent.com/LightForm-group/wiki/master/_includes/checklists/{{ exp_title -}}.yml</pre>
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
I started by putting it in the experiments directory but that meant it got published as an experiment! I think if it sits in the root directory it isn't included as an element in any other page. 

I can just scrape the URLs out of the body of this page. Doing it this way has the advantage that I also get the names of experiments that exist but don't have a template since their url will give a 404 error.