### PR TITLE
Converted datalight index to JSON and added layout: none

### DIFF
--- a/datalight_index.json
+++ b/datalight_index.json
@@ -1,14 +1,23 @@
 ---
+layout: none
 ---
 
 {% comment %} 
   # This page provides links to the experiment metadata files in the "/_includes/checklists" folder so DataLight can read them.
 {% endcomment %} 
 
+{
 {%- for exp in site.experiments -%}
   {%- assign exp_title = exp.title | replace: " ", "-" | downcase | replace: "(", "_" | replace: ")", "_" -%}
   {%- assign filename = exp.url | split: "/" -%}
-  {%- if filename[-1] != "index" -%}
-    <pre>https://raw.githubusercontent.com/LightForm-group/wiki/master/_includes/checklists/{{- exp_title -}}.yml</pre>
-  {%- endif -%}
+  {%- if filename[-1] != "index" %}
+    "{{ exp_title | remove: "_" }}": "https://raw.githubusercontent.com/LightForm-group/wiki/master/_includes/checklists/ {{- exp_title -}} .yml"
+  {%- endif %}
+  {%- case forloop.rindex -%}
+    {% when 1 %}  
+    {% when 2 %}
+    {%- else -%}
+      ,
+    {%- endcase -%}
 {%- endfor -%}
+}


### PR DESCRIPTION
Using layout: none in the header avoids the problem with the page being formatted.

A good suggestion to do it as JSON - I have done the JSON manually, it is a little messy to avoid the trailing comma but I think it should be robust.