### PR TITLE
Change matflow help to matflow_old

### DIFF
--- a/collections/_software_and_simulation/getting_matflow_help.md
+++ b/collections/_software_and_simulation/getting_matflow_help.md
@@ -4,9 +4,9 @@ author: Adam Plowman
 toc: true
 tags:
   - python
-  - matflow
+  - matflow-old
 published: true
-subcollection: MatFlow
+subcollection: MatFlow_old
 ---
 
 ## Getting help with MatFlow workflows

--- a/collections/_software_and_simulation/install_dev_version.md
+++ b/collections/_software_and_simulation/install_dev_version.md
@@ -4,9 +4,9 @@ author: Adam Plowman
 toc: true
 tags:
   - python
-  - matflow
+  - matflow-old
 published: true
-subcollection: MatFlow
+subcollection: MatFlow_old
 ---
 
 1. On the CSF, uninstall any "published" version of the package you wish to install from GitHub. For example, if you want to install a development version of the `matflow-damask` extension, first do `pip uninstall matflow-damask`. (Not sure if this step is required.)

--- a/collections/_software_and_simulation/matflow_first_time.md
+++ b/collections/_software_and_simulation/matflow_first_time.md
@@ -4,12 +4,12 @@ author: Peter Crowther
 toc: true
 tags:
   - python
-  - matflow
+  - matflow-old
   - workflow
   - yaml
   - yml
 published: true
-subcollection: MatFlow
+subcollection: MatFlow_old
 ---
 
 ## Installing MatFlow

--- a/collections/_software_and_simulation/matflow_post-processing.md
+++ b/collections/_software_and_simulation/matflow_post-processing.md
@@ -5,10 +5,10 @@ toc: true
 tags:
   - python
   - jupyter
-  - matflow
+  - matflow-old
   - damask
 published: true
-subcollection: MatFlow
+subcollection: MatFlow_old
 ---
 
 ## Exploring matflow workflow metadata and results

--- a/collections/_software_and_simulation/matflow_presentations.md
+++ b/collections/_software_and_simulation/matflow_presentations.md
@@ -3,9 +3,9 @@ title: MatFlow presentations
 author: Adam Plowman
 toc: true
 tags:
-  - matflow
+  - matflow-old
 published: true
-subcollection: MatFlow
+subcollection: MatFlow_old
 ---
 
 Click to download a PowerPoint presentation on MatFlow:

--- a/collections/_software_and_simulation/workflows.md
+++ b/collections/_software_and_simulation/workflows.md
@@ -2,10 +2,11 @@
 title: Towards fully reproducible scientific workflows
 author: Adam Plowman
 tags:
+  - matflow-old
   - simulation
 published: true
 toc: true
-subcollection: MatFlow
+subcollection: MatFlow_old
 ---
 
 ![matflow.png]({{site.baseurl}}/assets/images/posts/matflow.png)


### PR DESCRIPTION
Becuase matflow works completely differently now, our documentation as a research group has to change. However everything we have on matflows development is still very useful. Therefore I'm categorising everything related to the old version `matflow old`. 

I plan to start writing new documentation under the categorisation `matflow-new`